### PR TITLE
Update config.toml

### DIFF
--- a/src/config.toml
+++ b/src/config.toml
@@ -32,7 +32,7 @@ url = "https://github.com/submariner-io/"
 weight = 10
 
 [[Languages.en.menu.shortcuts]]
-name = "<i class='fas fa-fw fa-slack'></i> Slack"
+name = "<i class='fab fa-fw fa-slack'></i> Slack"
 identifier = "slack"
 url = "https://kubernetes.slack.com/archives/C010RJV694M"
 weight = 20


### PR DESCRIPTION
Tested this locally and the Slack icon did not show up properly. Class should be 'fab' and not 'fas' as proposed here.